### PR TITLE
Allow access to Result instances via ResultSet property access

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,9 @@ It defines the following methods:
 ```php
 final class ResultSet implements IteratorAggregate
 {
+    /** Returns the Result associated with $key, allowing property access to individual results */
+    public function __get(string $key): ?Result;
+
     public function getIterator(): Traversable;
 
     public function add(Result $result): void;
@@ -352,14 +355,19 @@ final class ResultSet implements IteratorAggregate
 }
 ```
 
-You can retrieve individual `Phly\RuleValidation\Result` instances using the `getResultForKey(string $key)` method.
-
 > Internally, `RuleSet` calls `freeze()` on a `ResultSet` before returning it from `RuleSet::validate()`.
+
+You can retrieve individual `Phly\RuleValidation\Result` instances using the `getResultForKey(string $key)` method, or via property access, using the key:
+
+```php
+$result = $results->getResultForKey('flag');
+$result = $results->flag;
+```
 
 Access individual results when generating an HTML form:
 
 ```php
-<?php $title = $results->getResultForKey('title'); // or $results['title'] ?>
+<?php $title = $results->title; // or $results->getResultForKey('title') ?>
 <input type="text" name="title" value="<?= $this->e($title->value) ?>">
 <?php if (! $title->isValid): ?>
 <p class="form-error"><?= $this->e($title->message) ?></p>

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -26,6 +26,11 @@ final class ResultSet implements IteratorAggregate
         }
     }
 
+    public function __get(string $key): ?Result
+    {
+        return array_key_exists($key, $this->results) ? $this->results[$key] : null;
+    }
+
     /** @return Traversable<Result> */
     public function getIterator(): Traversable
     {

--- a/test/ResultSetTest.php
+++ b/test/ResultSetTest.php
@@ -109,4 +109,18 @@ class ResultSetTest extends TestCase
         $this->expectException(ResultSetFrozenException::class);
         $resultSet->add(Result::forValidValue('flag', true));
     }
+
+    public function testAllowsAccessOfIndividualResultsViaPropertyAccessViaKey(): void
+    {
+        $result1   = Result::forValidValue('first', 1);
+        $result2   = Result::forValidValue('second', 2);
+        $result3   = Result::forInvalidValue('third', 3, 'not a valid value');
+        $result4   = Result::forValidValue('fourth', 4);
+        $resultSet = new ResultSet($result1, $result2, $result3, $result4);
+
+        $this->assertSame($result1, $resultSet->first);
+        $this->assertSame($result2, $resultSet->second);
+        $this->assertSame($result3, $resultSet->third);
+        $this->assertSame($result4, $resultSet->fourth);
+    }
 }


### PR DESCRIPTION
This patch modifies `ResultSet` to define:

```php
public function __get(string $key): ?Result;
```

The upshot is that this allows direct access to composed `Result` instances as if they were properties, which simplifies forms:

```php
<?php if (! $form->notes->isValid): ?>
<p class="text-danger"><?= $this->e($form->notes->message) ?></p>
<?php endif ?>
```
