### PR TITLE
Feature: valid rule set, type templates, nested rule set

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The explicit goals of this library are:
 Non-goals:
 
 - Creating an extensive set of validation rule classes.
-- Providing mechanisms for handling nested data sets.
+- Providing extensive mechanisms for validating and returning nested data sets.
 - Providing a configuration-driven mechanism for creating rule sets.
 - Providing HTML form input representations or all metadata required to create HTML form input representations.
 
@@ -107,15 +107,15 @@ This can be done with one of the following named constructors:
 ```php
 namespace Phly\RuleValidation;
 
-final class Result
+class Result
 {
     public const MISSING_MESSAGE = 'Missing required value';
 
-    public static function forValidValue(string $key, mixed $value): self;
+    final public static function forValidValue(string $key, mixed $value): self;
 
-    public static function forInvalidValue(string $key, mixed $value, string $message): self;
+    final public static function forInvalidValue(string $key, mixed $value, string $message): self;
 
-    public static function forMissingValue(string $key, string $message = self::MISSING_MESSAGE): self;
+    final public static function forMissingValue(string $key, string $message = self::MISSING_MESSAGE): self;
 }
 ```
 
@@ -553,4 +553,92 @@ If you are creating an anonymous class extending `RuleSet`, use the `@template-e
 $ruleSet = new /** @template-extends RuleSet<CustomResultSet> */ class extends RuleSet {
     // ...
 };
+```
+
+## Usage Examples
+
+### Nested result sets
+
+While this project does not aim to provide comprehensive support for nested result sets, it _is_ possible to do so, via the `Phly\RuleValidation\NestedResult` class.
+
+Within a `Rule::validate()` implementation, you can choose to return a `NestedResult` instead:
+
+```php
+$rule = new class implements Rule {
+    /** @var RuleSet{name: Result<string>, email: Result<string>} */
+    private RuleSet $rules;
+
+    public function __construct()
+    {
+        $this->rules = new RuleSet();
+        $this->rules->add(/* ... */); // name rule
+        $this->rules->add(/* ... */); // email rule
+    }
+
+    public function required(): bool
+    {
+        return true;
+    }
+
+    /** Return the key the Rule applies to */
+    public function key(): string
+    {
+        return 'author';
+    }
+
+    public function validate(mixed $value, array $context): NestedResult
+    {
+        if (! is_array($value)) {
+            $resultSet = new ResultSet();
+            $resultSet->add(Result::forMissingValue('name', 'Name is missing');
+            $resultSet->add(Result::forMissingValue('email', 'Email is missing');
+
+            // Note: returning a NestedResult instead of a Result
+            return NestedResult::forInvalidValue($this->key(), $resultset, 'author must be an array containing a name and email');
+        }
+
+        $result = $this->rules->validate($value)
+
+        if (! $result->isValid()) {
+            // Note: returning a NestedResult instead of a Result
+            return NestedResult::forInvalidValue($this->key(), $result, 'One or more elements of the author struct were invalid');
+        }
+
+        // Note: returning a NestedResult instead of a Result
+        return NestedResult::forValidValue($this->key(), $result);
+    }
+
+    /** @return RuleSet{name: Result<string>, email: Result<string>} */
+    public function default(): mixed
+    {
+        return $this->rules->createValidResultSet(['name' => '', 'email' => '']);
+    }
+};
+```
+
+Note that the returned `NestedResult` from `validate()` always contains a `ResultSet` as its value.
+`NestedResult` provides some convenience via `__isset()` and `__get()` to allow you to get at the `Result` instances of that `ResultSet`:
+
+```php
+<?php $author = $form->author; */
+<?php if (! $author->isValid): ?>
+<p class="text-warning">Please ensure valid author information is provided</p>
+<?php endif ?>
+<label for="author-name">Author Name</label>
+<input name="author[name]" id="author-name" type="text" value="<?= $this->e($author->name->value) ?>">
+<?php if (! $author->name->isValid): ?>
+<p class="text-warning"><?= $author->name->message ?></p>
+<?php endif ?>
+<label for="author-email">Author Name</label>
+<input name="author[email]" id="author-email" type="email" value="<?= $this->e($author->email->value) ?>">
+<?php if (! $author->email->isValid): ?>
+<p class="text-warning"><?= $author->email->message ?></p>
+<?php endif ?>
+```
+
+Calling `$author->value` will return the composed `ResultSet`, but calling on one of the composed result keys will give you the associated `Result` within the `ResultSet` directly.
+This is particularly useful when mapping values to a value object or when passing values as arguments:
+
+```php
+$author = new Author($author->name->value, $author->email->value);
 ```

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ public static function createWithResultSetClass(string $resultSetClass, Rule ...
 ```
 
 > When using this method, we recommend adding an annotation for your rule set variable to denote the result class used:
-> 
+>
 > ```php
 > /** @var RuleSet<MyCustomResultSet> $ruleSet */
 > $ruleSet = RuleSet::createWithResultSetClass(MyCustomResultSet::class);

--- a/README.md
+++ b/README.md
@@ -399,3 +399,76 @@ final readonly class Result
 ```
 
 Your `Rule` classes will produce `Result` instances using one of the named constructors (`forValidValue()`, `forInvalidValue()`), and your code can then access the state using the public properties (`$isValid`, `$value`, `$message`).
+
+## Providing types
+
+`Result::$value` provides a `mixed` hint, and a `ResultSet` is defined as composing arbitrary `Result` instances.
+This makes reasoning about what type of value is expected from results, and what results a result set composes, next to impossible.
+
+To provide a bit more safety, this library defines a number of template annotations.
+
+### Result
+
+The `Result` class allows templating the type of the `$value` it composes:
+
+```php
+/** @var Result<int> $count */
+$count = $resultSet->count;
+```
+
+### ResultSet
+
+The `ResultSet` class can be extended.
+When you do so, you may define property annotations for the class to define accessible `Result` instances:
+
+```php
+/**
+ * @property-read Result<string> $title
+ * @property-read Result<string> $description
+ * @property-read Result<DateTimeImmutable> $creationDate
+ */
+class CustomResultSet extends ResultSet
+{
+}
+```
+
+This will allow you to annotate instances:
+
+```php
+/** @var CustomResultSet $result */
+$result = $ruleSet->validate($data);
+```
+
+It also gives you a value you can use with rule sets...
+
+### RuleSet
+
+The `RuleSet` class defines `@template T of ResultSet`.
+This gives you a couple possibilities.
+
+For instance, when using the `RuleSet::createWithResultSetClass()` constructor, you could do the following:
+
+```php
+/** @var RuleSet<CustomResultSet> $ruleSet */
+$ruleSet = RuleSet::createWithResultSetClass(CustomResultSet::class);
+```
+
+Alternately, you could extend the class:
+
+```php
+/**
+ * @template-extends RuleSet<CustomResultSet>
+ */
+class MyRuleSet extends RuleSet
+{
+    protected string $resultSetClass = CustomResultSet::class;
+}
+```
+
+If you are creating an anonymous class extending `RuleSet`, use the `@template-extends` annotation:
+
+```php
+$ruleSet = new /** @template-extends RuleSet<CustomResultSet> */ class extends RuleSet {
+    // ...
+};
+```

--- a/README.md
+++ b/README.md
@@ -253,19 +253,19 @@ use Traversable;
 
 class RuleSet implements IteratorAggregate
 {
-    final public static function createWithResultSetClass(string $resultSetClass, Rule ...$rules): self;
+    public static function createWithResultSetClass(string $resultSetClass, Rule ...$rules): self;
 
-    final public function getIterator(): Traversable;
+    public function getIterator(): Traversable;
 
-    final public function add(Rule $rule): void;
+    public function add(Rule $rule): void;
 
     /** Returns the Rule where `Rule::key()` matches the `$key`, and null if none found */
-    final public function getRuleForKey(string $key): ?Rule;
+    public function getRuleForKey(string $key): ?Rule;
 
-    final public function validate(array $data): ResultSet;
+    public function validate(array $data): ResultSet;
 
     /** Use this method to create an initial result set for a form */
-    final public function createValidResultSet(array $valueMap = []): ResultSet;
+    public function createValidResultSet(array $valueMap = []): ResultSet;
 }
 ```
 
@@ -276,6 +276,13 @@ public function createMissingValueResultForKey(string $key): Result
 ```
 
 This method is covered below under the heading `Customizing "missing value" messages`.
+
+The class also defines one `protected` property for defining an alternate `ResultSet` implementation to create when validating:
+
+```php
+/** @var class-string<ResultSet> */
+protected string $resultSetClass = ResultSet::class;
+```
 
 ### Validation behavior
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "PhlyTest\\": "test/"
+            "PhlyTest\\RuleValidation\\": "test/"
         }
     },
     "scripts": {

--- a/src/Exception/RequiredRuleWithNoDefaultValueException.php
+++ b/src/Exception/RequiredRuleWithNoDefaultValueException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phly\RuleValidation\Exception;
+
+use Phly\RuleValidation\ResultSet;
+use RuntimeException;
+
+use function sprintf;
+
+class RequiredRuleWithNoDefaultValueException extends RuntimeException implements ValidationException
+{
+    /**
+     * @psalm-param non-empty-string $key
+     * @param class-string<ResultSet> $resultSetClass
+     */
+    public static function forKey(string $key, string $resultSetClass): self
+    {
+        return new self(sprintf(
+            // phpcs:ignore Generic.Files.LineLength.TooLong
+            'Unable to create valid %s instance; key "%s" is required, but has no default value; provide a value via the $valueMap argument',
+            $resultSetClass,
+            $key,
+        ), 500);
+    }
+}

--- a/src/NestedResult.php
+++ b/src/NestedResult.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phly\RuleValidation;
+
+use OutOfRangeException;
+use UnexpectedValueException;
+
+use function get_class;
+use function sprintf;
+
+/**
+ * Result extension representing a nested result.
+ *
+ * A NestedResult allows access to Result instances nested inside a ResultSet.
+ *
+ * <code>
+ * // in a Rule implementation:
+ * public function validate(mixed $value, array $context): Result
+ * {
+ *     $resultSet = $this->ruleSet->validate($value, $data);
+ *     return NestedResult::forValidValue($this->key(), $resultSet);
+ * </code>
+ *
+ * This allows more intuitive access to the results in a nested result set:
+ *
+ * <code>
+ * // Where $form is a ResultSet, and the $author property is a NestedResult,
+ * // with a ResultSet containing "name" and "email" properties:
+ * if ($form->author->isValid) {
+ *     new Author($form->author->name->value, $form->author->email->value);
+ * }
+ * </code>
+ *
+ * Values provided to NestedResult MUST be ResultSet instances.
+ *
+ * @template N
+ * @template-extends Result<N>
+ */
+class NestedResult extends Result
+{
+    /** @psalm-param non-empty-string $name */
+    public function __isset(string $name): bool
+    {
+        if (! $this->value instanceof ResultSet) {
+            return false;
+        }
+
+        return isset($this->value->$name);
+    }
+
+    /**
+     * @psalm-param non-empty-string $name
+     * @throws OutOfRangeException When the value property is not a ResultSet,
+     *     or the given $name is not a known property of the ResultSet.
+     */
+    public function __get(string $name): Result
+    {
+        if (! $this->value instanceof ResultSet) {
+            throw new OutOfRangeException(sprintf(
+                '%s instance does not compose a %s value; property access not available',
+                self::class,
+                ResultSet::class,
+            ));
+        }
+
+        if (! isset($this->value->$name)) {
+            throw new OutOfRangeException(sprintf(
+                '%s instance composed by %s does not contain a "%s" result',
+                get_class($this->value),
+                self::class,
+                $name,
+            ));
+        }
+
+        $value = $this->value->$name;
+
+        if (! $value instanceof Result) {
+            throw new UnexpectedValueException(sprintf(
+                'Value associated with "%s" is not a %s instance',
+                $name,
+                Result::class,
+            ));
+        }
+
+        return $value;
+    }
+}

--- a/src/Result.php
+++ b/src/Result.php
@@ -1,24 +1,22 @@
-<?php // phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols,SlevomatCodingStandard.TypeHints.DeclareStrictTypes.IncorrectWhitespaceBeforeDeclare
+<?php
 
 declare(strict_types=1);
 
 namespace Phly\RuleValidation;
 
-// @todo Remove file-level phpcs:disable once PSR1 ruleset understands readonly classes
-
 /**
  * @template T
  */
-final readonly class Result
+class Result
 {
     public const MISSING_MESSAGE = 'Missing required value';
 
-    private function __construct(
-        public string $key,
-        public bool $isValid,
+    final protected function __construct(
+        public readonly string $key,
+        public readonly bool $isValid,
         /** @var T */
-        public mixed $value,
-        public ?string $message = null,
+        public readonly mixed $value,
+        public readonly ?string $message = null,
     ) {
     }
 
@@ -27,16 +25,22 @@ final readonly class Result
      */
     public static function forValidValue(string $key, mixed $value): self
     {
-        return new self(key: $key, isValid: true, value: $value);
+        return new static(key: $key, isValid: true, value: $value);
     }
 
+    /**
+     * @return Result<T>
+     */
     public static function forInvalidValue(string $key, mixed $value, string $message): self
     {
-        return new self(key: $key, isValid: false, value: $value, message: $message);
+        return new static(key: $key, isValid: false, value: $value, message: $message);
     }
 
+    /**
+     * @return Result<T>
+     */
     public static function forMissingValue(string $key, string $message = self::MISSING_MESSAGE): self
     {
-        return new self(key: $key, isValid: false, value: null, message: $message);
+        return new static(key: $key, isValid: false, value: null, message: $message);
     }
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -22,6 +22,9 @@ final readonly class Result
     ) {
     }
 
+    /**
+     * @return Result<T>
+     */
     public static function forValidValue(string $key, mixed $value): self
     {
         return new self(key: $key, isValid: true, value: $value);

--- a/src/Result.php
+++ b/src/Result.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Phly\RuleValidation;
 
 // @todo Remove file-level phpcs:disable once PSR1 ruleset understands readonly classes
+
+/**
+ * @template T
+ */
 final readonly class Result
 {
     public const MISSING_MESSAGE = 'Missing required value';
@@ -12,6 +16,7 @@ final readonly class Result
     private function __construct(
         public string $key,
         public bool $isValid,
+        /** @var T */
         public mixed $value,
         public ?string $message = null,
     ) {

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -11,38 +11,59 @@ use Traversable;
 use function array_key_exists;
 use function array_reduce;
 
-/** @template-implements IteratorAggregate<Result> */
-final class ResultSet implements IteratorAggregate
+/**
+ * Validation result set
+ *
+ * The main reason to extend this class is to provide a list of expected Result
+ * mappings, with the expected Result value types:
+ *
+ * <code>
+ * /**
+ *  * @property-read Result<string> $title
+ *  * @property-read Result<string> $description
+ *  * @property-read Result<DateTimeImmutable> $creationDate
+ *  * /
+ * class CustomResultSet extends ResultSet
+ * {
+ * }
+ * </code>
+ *
+ * Doing so will give you IDE type hints, as well as allow Psalm and/or PHPStan
+ * to infer about composed Result instances correctly.
+ *
+ * @template-implements IteratorAggregate<Result>
+ */
+class ResultSet implements IteratorAggregate
 {
     private bool $frozen = false;
 
     /** @var array<string, Result> */
     private $results = [];
 
-    public function __construct(Result ...$results)
+    final public function __construct(Result ...$results)
     {
         foreach ($results as $result) {
             $this->add($result);
         }
     }
 
-    public function __isset(string $name): bool
+    final public function __isset(string $name): bool
     {
         return array_key_exists($name, $this->results);
     }
 
-    public function __get(string $key): ?Result
+    final public function __get(string $key): ?Result
     {
         return array_key_exists($key, $this->results) ? $this->results[$key] : null;
     }
 
     /** @return Traversable<Result> */
-    public function getIterator(): Traversable
+    final public function getIterator(): Traversable
     {
         return new ArrayIterator($this->results);
     }
 
-    public function add(Result $result): void
+    final public function add(Result $result): void
     {
         if ($this->frozen) {
             throw new Exception\ResultSetFrozenException();
@@ -54,7 +75,7 @@ final class ResultSet implements IteratorAggregate
     }
 
     /** @throws Exception\UnknownResultException */
-    public function getResultForKey(string $key): Result
+    final public function getResultForKey(string $key): Result
     {
         foreach ($this as $result) {
             if ($result->key === $key) {
@@ -65,7 +86,7 @@ final class ResultSet implements IteratorAggregate
         throw Exception\UnknownResultException::forKey($key);
     }
 
-    public function isValid(): bool
+    final public function isValid(): bool
     {
         return array_reduce($this->results, function (bool $isValid, Result $result): bool {
             if ($isValid === false) {
@@ -76,7 +97,7 @@ final class ResultSet implements IteratorAggregate
     }
 
     /** @return array<array-key, null|string> */
-    public function getMessages(): array
+    final public function getMessages(): array
     {
         $messages = [];
         foreach ($this->results as $key => $result) {
@@ -90,7 +111,7 @@ final class ResultSet implements IteratorAggregate
     }
 
     /** @return array<string, mixed> */
-    public function getValues(): array
+    final public function getValues(): array
     {
         $values = [];
         foreach ($this->results as $key => $result) {
@@ -108,7 +129,7 @@ final class ResultSet implements IteratorAggregate
      *
      * Once called, no more results may be added to the result set.
      */
-    public function freeze(): void
+    final public function freeze(): void
     {
         $this->frozen = true;
     }

--- a/src/ResultSet.php
+++ b/src/ResultSet.php
@@ -26,6 +26,11 @@ final class ResultSet implements IteratorAggregate
         }
     }
 
+    public function __isset(string $name): bool
+    {
+        return array_key_exists($name, $this->results);
+    }
+
     public function __get(string $key): ?Result
     {
         return array_key_exists($key, $this->results) ? $this->results[$key] : null;

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -16,6 +16,17 @@ class RuleSet implements IteratorAggregate
     /** @var array<string, Rule> */
     private array $rules = [];
 
+    /**
+     * Create a Result representing a missing value
+     *
+     * Override this method to customize the message used for individual (or all)
+     * missing values.
+     */
+    public function createMissingValueResultForKey(string $key): Result
+    {
+        return Result::forMissingValue($key);
+    }
+
     final public function __construct(Rule ...$rules)
     {
         foreach ($rules as $rule) {
@@ -69,15 +80,16 @@ class RuleSet implements IteratorAggregate
         return $resultSet;
     }
 
-    /**
-     * Create a Result representing a missing value
-     *
-     * Override this method to customize the message used for individual (or all)
-     * missing values.
-     */
-    public function createMissingValueResultForKey(string $key): Result
+    final public function createValidResultSet(array $valueMap): ResultSet
     {
-        return Result::forMissingValue($key);
+        $resultSet = new ResultSet();
+
+        foreach ($this->rules as $rule) {
+            $key = $rule->key();
+            $resultSet->add(Result::forValidValue($key, array_key_exists($key, $valueMap) ? $valueMap[$key] : $rule->default()));
+        }
+
+        return $resultSet;
     }
 
     /** @throws Exception\DuplicateRuleKeyException */

--- a/src/RuleSet.php
+++ b/src/RuleSet.php
@@ -16,11 +16,11 @@ use function array_key_exists;
  */
 class RuleSet implements IteratorAggregate
 {
+    /** @var class-string<T> */
+    protected string $resultSetClass = ResultSet::class;
+
     /** @var array<string, Rule> */
     private array $rules = [];
-
-    /** @var class-string<T> */
-    private string $resultSetClass = ResultSet::class;
 
     /**
      * Create a Result representing a missing value

--- a/test/NestedResultTest.php
+++ b/test/NestedResultTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhlyTest\RuleValidation;
+
+use OutOfRangeException;
+use Phly\RuleValidation\NestedResult;
+use Phly\RuleValidation\Result;
+use Phly\RuleValidation\ResultSet;
+use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
+
+class NestedResultTest extends TestCase
+{
+    public function testIssetReturnsFalseWhenComposedValueIsNotAResultSet(): void
+    {
+        $author = NestedResult::forValidValue('author', 'string');
+        $this->assertFalse(isset($author->name));
+    }
+
+    public function testIssetReturnsFalseWhenComposedValueIsAResultSetButDoesNotContainRequestedName(): void
+    {
+        $resultSet = new ResultSet();
+        $author    = NestedResult::forValidValue('author', $resultSet);
+        $this->assertFalse(isset($author->name));
+    }
+
+    public function testIssetReturnsTrueWhenComposedValueIsAResultSetAndContainsRequestedName(): void
+    {
+        $resultSet = new ResultSet(Result::forValidValue('name', 'Dirk Gently'));
+        $author    = NestedResult::forValidValue('author', $resultSet);
+        $this->assertTrue(isset($author->name));
+    }
+
+    public function testGetRaisesExceptionWhenComposedValueIsNotAResultSet(): void
+    {
+        /** @var NestedResult<Result<string>> $author */
+        $author = NestedResult::forValidValue('author', 'string');
+
+        $this->expectException(OutOfRangeException::class);
+        $author->name;
+    }
+
+    public function testGetRaisesExceptionWhenComposedValueIsAResultSetButDoesNotContainRequestedName(): void
+    {
+        $resultSet = new ResultSet();
+        /** @var NestedResult<Result<string>> $author */
+        $author = NestedResult::forValidValue('author', $resultSet);
+
+        $this->expectException(OutOfRangeException::class);
+        $author->name;
+    }
+
+    public function testGetRaisesExceptionWhenComposedValueIsAResultSetButValueAssociatedWithNameIsNotAResult(): void
+    {
+        $resultSet = new class extends ResultSet {
+            public string $name = 'Dirk Gently';
+        };
+        /** @var NestedResult<Result<string>> $author */
+        $author = NestedResult::forValidValue('author', $resultSet);
+
+        $this->expectException(UnexpectedValueException::class);
+        $author->name;
+    }
+
+    public function testGetReturnsResultAssociatedWithNameInComposedResultSet(): void
+    {
+        /** @var Result<string> $result */
+        $result    = Result::forValidValue('name', 'Dirk Gently');
+        $resultSet = new ResultSet($result);
+        /** @var NestedResult<Result<string>> $author */
+        $author = NestedResult::forValidValue('author', $resultSet);
+
+        $this->assertSame($result, $author->name);
+    }
+}

--- a/test/RuleSetTest.php
+++ b/test/RuleSetTest.php
@@ -218,4 +218,41 @@ class RuleSetTest extends TestCase
             }
         };
     }
+
+    public function testCreateValidResultSetCreatesValidResultSetUsingMap(): void
+    {
+        $ruleSet = new RuleSet();
+        $ruleSet->add($this->createDummyRule('first'));
+        $ruleSet->add($this->createDummyRule('second', required: true, default: 'string'));
+        $ruleSet->add($this->createDummyRule('third', default: 1));
+        $ruleSet->add($this->createDummyRule('fourth', required: true));
+
+        $form = $ruleSet->createValidResultSet(['first' => 'initial value', 'fourth' => 42]);
+
+        $this->assertInstanceOf(ResultSet::class, $form);
+
+        $this->assertTrue(isset($form->first));
+        $this->assertSame('initial value', $form->first->value);
+        $this->assertTrue(isset($form->second));
+        $this->assertSame('string', $form->second->value);
+        $this->assertTrue(isset($form->third));
+        $this->assertSame(1, $form->third->value);
+        $this->assertTrue(isset($form->fourth));
+        $this->assertSame(42, $form->fourth->value);
+    }
+
+    public function testCreateValidResultSetOmitsResultsForKeysNotMatchingAnyRules(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testCreateValidResultSetUsesNullForRulesWithNoDefaultValueAndNoValueInValueMap(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testCreateValidResultSetUsesProvidedResultSetClassNameWhenPresent(): void
+    {
+        $this->markTestIncomplete();
+    }
 }

--- a/test/TestAsset/CustomResultSet.php
+++ b/test/TestAsset/CustomResultSet.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhlyTest\RuleValidation\TestAsset;
+
+use Phly\RuleValidation\Result;
+use Phly\RuleValidation\ResultSet;
+
+/**
+ * @property-read Result<string> $first
+ * @property-read Result<string> $second
+ * @property-read Result<int> $third
+ * @property-read Result<null|int> $fourth
+ */
+class CustomResultSet extends ResultSet
+{
+}


### PR DESCRIPTION
This patch adds a number of features:

- Modifies `ResultSet` to allow extension; this is necessary so that developers can extend and provide `@property` or `@property-read` annotations mapping keys to specific result types.
- Adds a type template to `Result`, allowing the ability to indicate the expected type for the composed `$value`.
- Adds a type template to `RuleSet`, allowing the ability to indicate the expected `ResultSet` class from `validate()`.
- Adds a protected string property to `RuleSet`, `$resultSetClass`.
- Adds `RuleSet::createWithResultSetClass()` allows creating a `RuleSet` that will use the specified `ResultSet` class when creating a new result set during validation.
- Adds `RuleSet::createValidResultSet()`, which produces a valid result set with `Result` instances containing the values provided to the method, or the associated default values from the associated `Rule`s; this is generally for use with pre-populating forms in order to minimize logic.
- Modifies `Result` to remove the `final` and `readonly` keywords
  - All properties are defined as readonly
  - All methods are defined as final
  - The constructor is defined as final and protected, to ensure that the named constructors work with extensions.
- Adds `NestedResult`; this is intended to allow composing a `ResultSet` as a `$value` of a `NestedResult`, which then will proxy property calls to the nested `Result` instances of the composed `ResultSet`.

These features allow better extension, improved type inference, and greater flexibility around nested data sets.
