### PR TITLE
Allow usage with PHP 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "~8.2.0"
+        "php": "~8.2.0 || ~8.3.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",


### PR DESCRIPTION
Allow usage with PHP 8.3 by expanding PHP requirement in Composer config.

